### PR TITLE
Improve APIM build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ This artifact tested with the following version:
 
 ## Compile/Build
 
-In `build.gradle` file, update dependencies location:
-
-- Set the variable `apim_folder` to you API-Gateway installation folder (e.g. `opt/Axway/APIM/apigateway`)
+Set `apim_folder` to the API Gateway `system` folder so Gradle can compile against the APIM runtime jars:
 
 
 ```
-gradlew clean jar
+./gradlew clean jar -Papim_folder=/opt/Axway/apigateway/system
+```
+
+Alternatively, set `APIM_FOLDER`:
+
+```
+APIM_FOLDER=/opt/Axway/apigateway/system ./gradlew clean jar
 ```
 
 ## Setup
@@ -57,6 +61,7 @@ Copy following jar files
   - [opentelemetry-sdk-metrics-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.42.1/opentelemetry-sdk-metrics-1.42.1.jar)
   - [opentelemetry-sdk-trace-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.42.1/opentelemetry-sdk-trace-1.42.1.jar)
   - [opentelemetry-runtime-telemetry-java8-2.18.1-alpha.jar](https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-runtime-telemetry-java8/2.18.1-alpha/opentelemetry-runtime-telemetry-java8-2.18.1-alpha.jar)
+  - [opentelemetry-instrumentation-api-2.18.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-api/2.18.1/opentelemetry-instrumentation-api-2.18.1.jar)
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,24 @@ tasks.withType(JavaCompile) {
     options.compilerArgs += ['-Xlint:deprecation']
 }
 
-def apim_folder = '/Users/rnatarajan/v7apim/may2023/system'
+def apim_folder = providers.gradleProperty('apim_folder')
+    .orElse(providers.environmentVariable('APIM_FOLDER'))
+    .getOrElse('')
+
+if (!apim_folder) {
+    throw new GradleException('Set the APIM system folder with -Papim_folder=/path/to/apigateway/system or APIM_FOLDER=/path/to/apigateway/system')
+}
+
+def apimSystemDir = file(apim_folder)
+if (!apimSystemDir.isDirectory()) {
+    throw new GradleException("APIM system folder does not exist: ${apimSystemDir}")
+}
 
 def opentelemetry_version = "1.42.1"
 dependencies {
-    implementation fileTree(dir: "${apim_folder}/lib", include: '*.jar')
-    implementation fileTree(dir: "${apim_folder}/lib/jce", include: '*.jar')
-    implementation fileTree(dir: "${apim_folder}/lib/plugins", include: '*.jar')
+    implementation fileTree(dir: "${apimSystemDir}/lib", include: '*.jar')
+    implementation fileTree(dir: "${apimSystemDir}/lib/jce", include: '*.jar')
+    implementation fileTree(dir: "${apimSystemDir}/lib/plugins", include: '*.jar')
     implementation group: 'org.aspectj', name: 'aspectjweaver', version: '1.9.22.1'
     implementation("io.opentelemetry:opentelemetry-api:${opentelemetry_version}")
     implementation("io.opentelemetry:opentelemetry-sdk:${opentelemetry_version}")


### PR DESCRIPTION
## Summary

- make the APIM system folder configurable with `-Papim_folder=...` or `APIM_FOLDER=...` instead of requiring a local hard-coded path in `build.gradle`
- document both build options in the README
- add the missing `opentelemetry-instrumentation-api-2.18.1.jar` runtime dependency to the manual setup list
- align the AspectJ setup text with the linked/sample `aspectjweaver-1.9.22.1.jar` version

## Validation

- Built successfully on an APIM EC2 test host with:

```bash
./gradlew clean jar -Papim_folder=/opt/Axway/apigateway/system
```

- In the same APIM test install, with AspectJ active and the documented runtime jars plus OkHttp present, ANM loads and login works when `opentelemetry-instrumentation-api-2.18.1.jar` is present. Removing only that jar causes ANM to error before the login page.

## Notes

This is intended as a small unblocker PR for build reproducibility and the missing runtime dependency. A separate draft PR adds an `assembleInstall` task so the runtime jar set does not need to be manually maintained.