### PR TITLE
Add APIM agent install assembly task

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,46 +24,26 @@ Alternatively, set `APIM_FOLDER`:
 APIM_FOLDER=/opt/Axway/apigateway/system ./gradlew clean jar
 ```
 
+To assemble the agent jar and required runtime dependency jars into one install directory, run:
+
+```
+./gradlew clean assembleInstall -Papim_folder=/opt/Axway/apigateway/system
+```
+
+The install directory is created at `build/install/opentelemetry-apim-agent`.
+
+The assembled directory is the source of truth for the runtime jar set. To review the exact files Gradle resolved for this build, run:
+
+```
+ls -1 build/install/opentelemetry-apim-agent/*.jar
+```
+
 ## Setup
 
-Copy following jar files
+Copy the assembled jar files:
 
-
-- Copy opentelemetry-apim-agent--x.x.x.jar file to apigateway/ext/lib
-- Copy Aspectj weaver - [ aspectjweaver-1.9.6.jar ](https://repo1.maven.org/maven2/org/aspectj/aspectjweaver/1.9.22.1/aspectjweaver-1.9.22.1.jar) to  apigateway/ext/lib
-- Copy opentelmetry sdk jar files to apigateway/ext/lib 
-
-  - [okhttp-4.12.0.jar](https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.jar)
-  - [okio-jvm-3.6.0.jar](https://repo1.maven.org/maven2/com/squareup/okio/okio-jvm/3.6.0/okio-jvm-3.6.0.jar)
-  - [kotlin-stdlib-1.9.25.jar](https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.25/kotlin-stdlib-1.9.25.jar)
-
-  - [opentelemetry-semconv-1.27.0-alpha.jar](https://repo1.maven.org/maven2/io/opentelemetry/semconv/opentelemetry-semconv/1.27.0-alpha/opentelemetry-semconv-1.27.0-alpha.jar)
-  
-  - [opentelemetry-api-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-api/1.42.1/opentelemetry-api-1.42.1.jar)
-  - [opentelemetry-api-incubator-1.42.1-alpha.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-api-incubator/1.42.1-alpha/opentelemetry-api-incubator-1.42.1-alpha.jar)
-  
-  - [opentelemetry-context-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-context/1.42.1/opentelemetry-context-1.42.1.jar)
-
-  - [opentelemetry-exporter-common-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-common/1.42.1/opentelemetry-exporter-common-1.42.1.jar)
-  - [opentelemetry-exporter-logging-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-logging/1.42.1/opentelemetry-exporter-logging-1.42.1.jar)
-  - [opentelemetry-exporter-otlp-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-otlp/1.42.1/opentelemetry-exporter-otlp-1.42.1.jar)
-  - [opentelemetry-exporter-otlp-common-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-otlp-common/1.42.1/opentelemetry-exporter-otlp-common-1.42.1.jar)
-  - [opentelemetry-exporter-sender-okhttp-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-sender-okhttp/1.42.1/opentelemetry-exporter-sender-okhttp-1.42.1.jar)
-
-  - [opentelemetry-sdk-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk/1.42.1/opentelemetry-sdk-1.42.1.jar)
-  - [opentelemetry-sdk-common-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-common/1.42.1/opentelemetry-sdk-common-1.42.1.jar)
-  - [opentelemetry-sdk-extension-autoconfigure-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.42.1/opentelemetry-sdk-extension-autoconfigure-1.42.1.jar)
-  - [opentelemetry-sdk-extension-autoconfigure-spi-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/1.42.1/opentelemetry-sdk-extension-autoconfigure-spi-1.42.1.jar)
- 
-  
-  - [opentelemetry-extension-incubator-1.30.1-alpha.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-extension-incubator/1.30.1-alpha/opentelemetry-extension-incubator-1.30.1-alpha.jar)
-  - [opentelemetry-sdk-logs-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-logs/1.42.1/opentelemetry-sdk-logs-1.42.1.jar)
-  - [opentelemetry-sdk-metrics-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.42.1/opentelemetry-sdk-metrics-1.42.1.jar)
-  - [opentelemetry-sdk-trace-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.42.1/opentelemetry-sdk-trace-1.42.1.jar)
-  - [opentelemetry-runtime-telemetry-java8-2.18.1-alpha.jar](https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-runtime-telemetry-java8/2.18.1-alpha/opentelemetry-runtime-telemetry-java8-2.18.1-alpha.jar)
-  - [opentelemetry-instrumentation-api-2.18.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-api/2.18.1/opentelemetry-instrumentation-api-2.18.1.jar)
-
-
+- Copy all jar files from `build/install/opentelemetry-apim-agent` to `apigateway/ext/lib`.
+- Remove any previously copied OpenTelemetry/APIM agent jars from `apigateway/ext/lib` before copying the newly assembled jars. Do not leave older OpenTelemetry versions beside the assembled set.
 
 - Create a file named jvm.xml under APIGATEWAY_INSTALL_DIR/apigateway/conf/
     ```xml

--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ This artifact tested with the following version:
 
 ## Compile/Build
 
-In `build.gradle` file, update dependencies location:
-
-- Set the variable `apim_folder` to you API-Gateway installation folder (e.g. `opt/Axway/APIM/apigateway`)
+Set `apim_folder` to the API Gateway `system` folder so Gradle can compile against the APIM runtime jars:
 
 
 ```
-gradlew clean jar
+./gradlew clean jar -Papim_folder=/opt/Axway/apigateway/system
+```
+
+Alternatively, set `APIM_FOLDER`:
+
+```
+APIM_FOLDER=/opt/Axway/apigateway/system ./gradlew clean jar
 ```
 
 ## Setup
@@ -57,6 +61,7 @@ Copy following jar files
   - [opentelemetry-sdk-metrics-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/1.42.1/opentelemetry-sdk-metrics-1.42.1.jar)
   - [opentelemetry-sdk-trace-1.42.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.42.1/opentelemetry-sdk-trace-1.42.1.jar)
   - [opentelemetry-runtime-telemetry-java8-2.18.1-alpha.jar](https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-runtime-telemetry-java8/2.18.1-alpha/opentelemetry-runtime-telemetry-java8-2.18.1-alpha.jar)
+  - [opentelemetry-instrumentation-api-2.18.1.jar](https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-api/2.18.1/opentelemetry-instrumentation-api-2.18.1.jar)
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,24 @@ tasks.withType(JavaCompile) {
     options.compilerArgs += ['-Xlint:deprecation']
 }
 
-def apim_folder = '/Users/rnatarajan/v7apim/may2023/system'
+def apim_folder = providers.gradleProperty('apim_folder')
+    .orElse(providers.environmentVariable('APIM_FOLDER'))
+    .getOrElse('')
+
+if (!apim_folder) {
+    throw new GradleException('Set the APIM system folder with -Papim_folder=/path/to/apigateway/system or APIM_FOLDER=/path/to/apigateway/system')
+}
+
+def apimSystemDir = file(apim_folder)
+if (!apimSystemDir.isDirectory()) {
+    throw new GradleException("APIM system folder does not exist: ${apimSystemDir}")
+}
 
 def opentelemetry_version = "1.42.1"
 dependencies {
-    implementation fileTree(dir: "${apim_folder}/lib", include: '*.jar')
-    implementation fileTree(dir: "${apim_folder}/lib/jce", include: '*.jar')
-    implementation fileTree(dir: "${apim_folder}/lib/plugins", include: '*.jar')
+    implementation fileTree(dir: "${apimSystemDir}/lib", include: '*.jar')
+    implementation fileTree(dir: "${apimSystemDir}/lib/jce", include: '*.jar')
+    implementation fileTree(dir: "${apimSystemDir}/lib/plugins", include: '*.jar')
     implementation group: 'org.aspectj', name: 'aspectjweaver', version: '1.9.22.1'
     implementation("io.opentelemetry:opentelemetry-api:${opentelemetry_version}")
     implementation("io.opentelemetry:opentelemetry-sdk:${opentelemetry_version}")

--- a/build.gradle
+++ b/build.gradle
@@ -33,22 +33,33 @@ if (!apimSystemDir.isDirectory()) {
     throw new GradleException("APIM system folder does not exist: ${apimSystemDir}")
 }
 
-def opentelemetry_version = "1.42.1"
+configurations {
+    apimAgentRuntime {
+        canBeConsumed = false
+        canBeResolved = true
+    }
+    implementation.extendsFrom(apimAgentRuntime)
+}
+
+def opentelemetry_version = "1.52.0"
+def opentelemetry_instrumentation_version = "2.18.1"
+def opentelemetry_semconv_version = "1.34.0"
 dependencies {
     implementation fileTree(dir: "${apimSystemDir}/lib", include: '*.jar')
     implementation fileTree(dir: "${apimSystemDir}/lib/jce", include: '*.jar')
     implementation fileTree(dir: "${apimSystemDir}/lib/plugins", include: '*.jar')
-    implementation group: 'org.aspectj', name: 'aspectjweaver', version: '1.9.22.1'
-    implementation("io.opentelemetry:opentelemetry-api:${opentelemetry_version}")
-    implementation("io.opentelemetry:opentelemetry-sdk:${opentelemetry_version}")
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:${opentelemetry_version}")
+    apimAgentRuntime group: 'org.aspectj', name: 'aspectjweaver', version: '1.9.22.1'
+    apimAgentRuntime("io.opentelemetry:opentelemetry-api:${opentelemetry_version}")
+    apimAgentRuntime("io.opentelemetry:opentelemetry-sdk:${opentelemetry_version}")
+    apimAgentRuntime("io.opentelemetry:opentelemetry-exporter-otlp:${opentelemetry_version}")
 
-    implementation("io.opentelemetry:opentelemetry-sdk-metrics:${opentelemetry_version}")
-    implementation("io.opentelemetry:opentelemetry-exporter-logging:${opentelemetry_version}")
-    implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${opentelemetry_version}")
+    apimAgentRuntime("io.opentelemetry:opentelemetry-sdk-metrics:${opentelemetry_version}")
+    apimAgentRuntime("io.opentelemetry:opentelemetry-exporter-logging:${opentelemetry_version}")
+    apimAgentRuntime("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${opentelemetry_version}")
    // implementation("io.opentelemetry:opentelemetry-semconv:1.30.1-alpha")
-    implementation "io.opentelemetry.semconv:opentelemetry-semconv:1.27.0-alpha"
-    implementation "io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8:2.18.1-alpha"
+    apimAgentRuntime "io.opentelemetry.semconv:opentelemetry-semconv:${opentelemetry_semconv_version}"
+    apimAgentRuntime "io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8:${opentelemetry_instrumentation_version}-alpha"
+    apimAgentRuntime "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${opentelemetry_instrumentation_version}"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
@@ -57,4 +68,13 @@ dependencies {
 }
 jar {
     metaInf { from('src/main/resources/aop.xml') }
+}
+
+tasks.register('assembleInstall', Copy) {
+    group = 'distribution'
+    description = 'Assembles the APIM agent jar and required runtime dependency jars for apigateway/ext/lib.'
+    dependsOn jar
+    into layout.buildDirectory.dir('install/opentelemetry-apim-agent')
+    from(tasks.named('jar'))
+    from(configurations.apimAgentRuntime)
 }


### PR DESCRIPTION
## Summary

- add an `apimAgentRuntime` Gradle configuration for the external runtime jars needed in `apigateway/ext/lib`
- add `assembleInstall` to build the APIM agent jar and copy the resolved runtime dependency set into `build/install/opentelemetry-apim-agent`
- update setup docs so the assembled directory is the source of truth instead of a hand-maintained jar inventory
- align the OpenTelemetry SDK/exporter versions with the dependency versions resolved by `opentelemetry-instrumentation-api:2.18.1`

## Validation

Tested on an APIM EC2 host with:

```bash
./gradlew clean assembleInstall -Papim_folder=/opt/Axway/apigateway/system
```

The assembled jars were copied into `apigateway/ext/lib`, APIM was restarted, ANM login worked, and API execution produced OpenTelemetry output. Jaeger showed service `apim-gw`, trace `GET PetStore`, two spans, and the outbound HTTP span for `https://petstore.swagger.io/v2/store/inventory`.

## Stack note

This draft is stacked on #8. It is expected to show the #8 build-configuration commit until #8 merges. The assembly change itself is the top commit on branch `feature/assemble-runtime-libs`.